### PR TITLE
Laurel symbol, previews, and adopt Observation

### DIFF
--- a/Sources/ReviewKit/ReviewKit.swift
+++ b/Sources/ReviewKit/ReviewKit.swift
@@ -22,17 +22,27 @@ public struct ShapeProgressView: View {
     let color: Color
     let layout: LayoutType
     let showReviewCount: Bool
+    let showLaurels: Bool
     let countryCode: String
     
     @StateObject private var reviewManager: ReviewManager
     
-    public init(appId: String, count: Int = 5, imageName: String = "star", color: Color = .orange, layout: LayoutType = .full, showReviewCount: Bool = true, countryCode: String = "US") {
+    public init(appId: String,
+                count: Int = 5,
+                imageName: String = "star",
+                color: Color = .orange,
+                layout: LayoutType = .full,
+                showReviewCount: Bool = true,
+                showLaurels: Bool = true,
+                countryCode: String = "US"
+    ) {
         self.appId = appId
         self.count = count
         self.imageName = imageName
         self.color = color
         self.layout = layout
         self.showReviewCount = showReviewCount
+        self.showLaurels = showLaurels
         self.countryCode = countryCode
         self._reviewManager = StateObject(wrappedValue: ReviewManager(appId: appId, countryCode: countryCode))
     }
@@ -41,11 +51,25 @@ public struct ShapeProgressView: View {
         VStack(spacing: 8) {
             switch layout {
             case .full:
-                Text("\(reviewManager.rating, specifier: "%.1f")")
-                    .fontDesign(.rounded)
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
-                
+                HStack {
+                    if showLaurels {
+                        Image(systemName: "laurel.leading")
+                            .font(.largeTitle)
+                            .fontWeight(.bold)
+                    }
+
+                    Text("\(reviewManager.rating, specifier: "%.1f")")
+                        .fontDesign(.rounded)
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+
+                    if showLaurels {
+                        Image(systemName: "laurel.trailing")
+                            .font(.largeTitle)
+                            .fontWeight(.bold)
+                    }
+                }
+
                 ZStack {
                     ShapeRow(count: count, imageName: imageName, position: .background, color: color, value: $reviewManager.rating)
                     ShapeRow(count: count, imageName: imageName, position: .foreground, color: color, value: $reviewManager.rating)
@@ -55,11 +79,25 @@ public struct ShapeProgressView: View {
                     Text(reviewManager.reviewCount > 0 ? "Based on \(reviewManager.reviewCount, specifier: "%.0f") reviews" : "No reviews yet")
                 }
             case .score:
-                Text("\(reviewManager.rating, specifier: "%.1f")")
-                    .fontDesign(.rounded)
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
-                
+                HStack {
+                    if showLaurels {
+                        Image(systemName: "laurel.leading")
+                            .font(.largeTitle)
+                            .fontWeight(.bold)
+                    }
+
+                    Text("\(reviewManager.rating, specifier: "%.1f")")
+                        .fontDesign(.rounded)
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+
+                    if showLaurels {
+                        Image(systemName: "laurel.trailing")
+                            .font(.largeTitle)
+                            .fontWeight(.bold)
+                    }
+                }
+
                 if showReviewCount {
                     Text(reviewManager.reviewCount > 0 ? "Based on \(reviewManager.reviewCount, specifier: "%.0f") reviews" : "No reviews yet")
                 }
@@ -87,5 +125,15 @@ public struct ShapeProgressView: View {
                 print("Trying to fetch App Store rating failed due to an unknown error.")
             }
         }
+    }
+}
+
+#Preview {
+    VStack(spacing: 64) {
+        ShapeProgressView(appId: "389801252", layout: .full)
+
+        ShapeProgressView(appId: "389801252", layout: .graphical)
+
+        ShapeProgressView(appId: "389801252", layout: .score)
     }
 }

--- a/Sources/ReviewKit/ReviewKit.swift
+++ b/Sources/ReviewKit/ReviewKit.swift
@@ -54,21 +54,17 @@ public struct ShapeProgressView: View {
                 HStack {
                     if showLaurels {
                         Image(systemName: "laurel.leading")
-                            .font(.largeTitle)
-                            .fontWeight(.bold)
                     }
 
                     Text("\(reviewManager.rating, specifier: "%.1f")")
                         .fontDesign(.rounded)
-                        .font(.largeTitle)
-                        .fontWeight(.bold)
 
                     if showLaurels {
                         Image(systemName: "laurel.trailing")
-                            .font(.largeTitle)
-                            .fontWeight(.bold)
                     }
                 }
+                .font(.largeTitle)
+                .fontWeight(.bold)
 
                 ZStack {
                     ShapeRow(count: count, imageName: imageName, position: .background, color: color, value: $reviewManager.rating)
@@ -82,21 +78,17 @@ public struct ShapeProgressView: View {
                 HStack {
                     if showLaurels {
                         Image(systemName: "laurel.leading")
-                            .font(.largeTitle)
-                            .fontWeight(.bold)
                     }
 
                     Text("\(reviewManager.rating, specifier: "%.1f")")
                         .fontDesign(.rounded)
-                        .font(.largeTitle)
-                        .fontWeight(.bold)
 
                     if showLaurels {
                         Image(systemName: "laurel.trailing")
-                            .font(.largeTitle)
-                            .fontWeight(.bold)
                     }
                 }
+                .font(.largeTitle)
+                .fontWeight(.bold)
 
                 if showReviewCount {
                     Text(reviewManager.reviewCount > 0 ? "Based on \(reviewManager.reviewCount, specifier: "%.0f") reviews" : "No reviews yet")

--- a/Sources/ReviewKit/ReviewKit.swift
+++ b/Sources/ReviewKit/ReviewKit.swift
@@ -25,7 +25,7 @@ public struct ShapeProgressView: View {
     let showLaurels: Bool
     let countryCode: String
     
-    @StateObject private var reviewManager: ReviewManager
+    @State private var reviewManager: ReviewManager
     
     public init(appId: String,
                 count: Int = 5,
@@ -44,7 +44,7 @@ public struct ShapeProgressView: View {
         self.showReviewCount = showReviewCount
         self.showLaurels = showLaurels
         self.countryCode = countryCode
-        self._reviewManager = StateObject(wrappedValue: ReviewManager(appId: appId, countryCode: countryCode))
+        self._reviewManager = State(wrappedValue: ReviewManager(appId: appId, countryCode: countryCode))
     }
     
     public var body: some View {
@@ -129,11 +129,14 @@ public struct ShapeProgressView: View {
 }
 
 #Preview {
-    VStack(spacing: 64) {
-        ShapeProgressView(appId: "389801252", layout: .full)
+    // ID for Instagram
+    let appId = "389801252"
 
-        ShapeProgressView(appId: "389801252", layout: .graphical)
+    return VStack(spacing: 64) {
+        ShapeProgressView(appId: appId, layout: .full)
 
-        ShapeProgressView(appId: "389801252", layout: .score)
+        ShapeProgressView(appId: appId, layout: .graphical)
+
+        ShapeProgressView(appId: appId, layout: .score)
     }
 }

--- a/Sources/ReviewKit/ReviewManager.swift
+++ b/Sources/ReviewKit/ReviewManager.swift
@@ -67,10 +67,11 @@ public enum AppStoreResponseError: Error {
     case invalidData
 }
 
-class ReviewManager: ObservableObject {
-    @Published var rating: Double
-    @Published var reviewCount: Double
-    @Published var isLoading: Bool
+@Observable
+class ReviewManager {
+    var rating: Double
+    var reviewCount: Double
+    var isLoading: Bool
     let appId: String
     let countryCode: String
     


### PR DESCRIPTION
## Laurel Symbols
Added `showLaurels` parameter that adds new styling options for both `.full` and `.score` layouts. 
Currently defaults to true but maybe false would be better?

<img width="235" alt="Screenshot 2024-02-16 at 7 46 13 PM" src="https://github.com/ordinaryindustries/ReviewKit/assets/26508262/6cc54cf8-20bd-400e-be46-095fcdb489e5">

## Previews
Added a preview to `ReviewKit.swift` to show the different layout options. 

## Observation
Since the minimum versions are high enough, went ahead and adopted the new `@Observable` from `ObservableObject`.