### PR TITLE
add support for setting foreground style

### DIFF
--- a/Sources/ReviewKit/ReviewKit.swift
+++ b/Sources/ReviewKit/ReviewKit.swift
@@ -21,6 +21,7 @@ public struct ShapeProgressView: View {
     let count: Int
     let imageName: String
     let color: Color
+    let textColor: Color
     let layout: LayoutType
     let showReviewCount: Bool
     let showLaurels: Bool
@@ -32,6 +33,7 @@ public struct ShapeProgressView: View {
                 count: Int = 5,
                 imageName: String = "star",
                 color: Color = .orange,
+                textColor: Color = .black,
                 layout: LayoutType = .full,
                 showReviewCount: Bool = true,
                 showLaurels: Bool = true,
@@ -41,6 +43,7 @@ public struct ShapeProgressView: View {
         self.count = count
         self.imageName = imageName
         self.color = color
+        self.textColor = textColor
         self.layout = layout
         self.showReviewCount = showReviewCount
         self.showLaurels = showLaurels
@@ -78,6 +81,7 @@ public struct ShapeProgressView: View {
                         : reviewManager.localizedString(forKey: "rating.reviews.noReviews")
                     
                     Text(reviewCountText)
+                        .foregroundStyle(textColor)
                 }
             case .score:
                 HStack {
@@ -101,7 +105,9 @@ public struct ShapeProgressView: View {
                         : reviewManager.localizedString(forKey: "rating.reviews.noReviews")
                     
                     Text(reviewCountText)
+                        .foregroundColor(textColor)
                 }
+
             case .graphical:
                 ZStack {
                     RatingRow(count: count, imageName: imageName, position: .background, color: color, value: $reviewManager.rating)
@@ -110,6 +116,7 @@ public struct ShapeProgressView: View {
                 
                 if showReviewCount {
                     Text(reviewManager.reviewCount > 0 ? "Based on \(reviewManager.reviewCount, specifier: "%.0f") reviews" : "No reviews yet")
+                        .foregroundColor(textColor)
                 }
             }
         }
@@ -134,6 +141,7 @@ public struct RatingView: View {
     let count: Int
     let imageName: String
     let color: Color
+    let textColor: Color
     let layout: LayoutType
     let showReviewCount: Bool
     let showLaurels: Bool
@@ -145,6 +153,7 @@ public struct RatingView: View {
                 count: Int = 5,
                 imageName: String = "star",
                 color: Color = .orange,
+                textColor: Color = .black,
                 layout: LayoutType = .full,
                 showReviewCount: Bool = true,
                 showLaurels: Bool = true,
@@ -154,6 +163,7 @@ public struct RatingView: View {
         self.count = count
         self.imageName = imageName
         self.color = color
+        self.textColor = textColor
         self.layout = layout
         self.showReviewCount = showReviewCount
         self.showLaurels = showLaurels
@@ -187,6 +197,7 @@ public struct RatingView: View {
                 
                 if showReviewCount {
                     Text(reviewManager.reviewCount > 0 ? "Based on \(reviewManager.reviewCount, specifier: "%.0f") reviews" : "No reviews yet")
+                        .foregroundColor(textColor)
                 }
             case .score:
                 HStack {
@@ -206,6 +217,7 @@ public struct RatingView: View {
 
                 if showReviewCount {
                     Text(reviewManager.reviewCount > 0 ? "Based on \(reviewManager.reviewCount, specifier: "%.0f") reviews" : "No reviews yet")
+                        .foregroundColor(textColor)
                 }
             case .graphical:
                 ZStack {
@@ -219,6 +231,7 @@ public struct RatingView: View {
                         : reviewManager.localizedString(forKey: "rating.reviews.noReviews")
                     
                     Text(reviewCountText)
+                        .foregroundColor(textColor)
                 }
             }
         }
@@ -245,8 +258,11 @@ public struct RatingView: View {
     return VStack(spacing: 64) {
         RatingView(appId: appId, layout: .full)
 
-        RatingView(appId: appId, layout: .graphical)
+        RatingView(appId: appId, textColor: .blue, layout: .graphical)
 
-        RatingView(appId: appId, layout: .score)
+        RatingView(appId: appId, textColor: .green, layout: .score)
+        
+        // MARK - Verifying Backward Compatibility
+        ShapeProgressView(appId: appId, textColor: .brown)
     }
 }


### PR DESCRIPTION
This branch adds support for setting foreground style. It enables developers to choose their color of preference to set for the review count text.
![Screenshot 2024-10-12 at 10 53 08 AM](https://github.com/user-attachments/assets/078cde57-d955-49b4-99f2-5441ba324e90)
